### PR TITLE
Update FtpClient.php

### DIFF
--- a/src/FtpClient/FtpClient.php
+++ b/src/FtpClient/FtpClient.php
@@ -399,11 +399,13 @@ class FtpClient implements Countable
     public function rmdir($directory, $recursive = true)
     {
         if ($recursive) {
+	    //if directory has absolute path, keep absolute path for files
+	    $path = (substr($directory, 0, 1) === '/') ? '':$directory;
             $files = $this->nlist($directory, false, 'rsort');
 
             // remove children
             foreach ($files as $file) {
-                $this->remove($directory.'/'.$file, true);
+                $this->remove($path.'/'.$file, true);
             }
         }
 


### PR DESCRIPTION
If an absolute path is passed to rmdir method, line $this->remove($directory.'/'.$file, true); will duplicate the path file like
/var/www/html/myfolder/todelete//var/www/html/myfolder/todelete/myfile.pdf